### PR TITLE
7903219: Improve version check, and related doc update

### DIFF
--- a/src/classes/doccheck/html/TidyChecker.java
+++ b/src/classes/doccheck/html/TidyChecker.java
@@ -57,7 +57,7 @@ import doccheck.Reporter;
 public class TidyChecker implements FileChecker {
     private final Log log;
     private boolean passed;
-    private Path TIDY;
+    private final Path TIDY;
 
     private Path path;
 
@@ -127,11 +127,15 @@ public class TidyChecker implements FileChecker {
                          new BufferedReader(new InputStreamReader(p.getInputStream()))) {
                 List<String> lines = r.lines().collect(Collectors.toList());
                 // Look for a line containing "version" and a dotted identifier beginning 5.
+                // If not found, look for known old/bad versions, to report in error message
                 Pattern version = Pattern.compile("version.* [5678]\\.[0-9]+(\\.[0-9]+)");
                 if (lines.stream().noneMatch(line -> version.matcher(line).find())) {
+                    Pattern oldVersion = Pattern.compile("2006");  // 2006 implies old macOS version
                     String lineSep = System.lineSeparator();
-                    log.error("Could not determine the version of 'tidy' on the PATH\n" +
-                            String.join(lineSep, lines));
+                    String message = lines.stream().anyMatch(line -> oldVersion.matcher(line).find())
+                        ? "old version of 'tidy' found of  the PATH\n"
+                        : "could not determine the version of 'tidy' on the PATH\n";
+                    log.error(message + String.join(lineSep, lines));
                 }
             }
         } catch (IOException e) {

--- a/src/doc/doccheck.md
+++ b/src/doc/doccheck.md
@@ -7,27 +7,27 @@ of any possible issues.
 
 It supports the following checks:
 
-+   *HTML* -- `doccheck` leverages the standard [tidy] utility to check for HTML 
++ *HTML* -- `doccheck` leverages the standard [tidy] utility to check for HTML 
     compliance, according to the declared version of HTML. The output from `tidy` 
     is analysed to generate a report summarizing any issues that were found.
 
-+   *Accessibility* -- `doccheck` provides some very basic checking for
++ *Accessibility* -- `doccheck` provides some very basic checking for
     accessibility, such as declaring a default language, tables having captions
     and row/column headers, and so on.
 
-+   *Bad Characters* -- `doccheck` assumes that HTML files are encoded in UTF-8,
++ *Bad Characters* -- `doccheck` assumes that HTML files are encoded in UTF-8,
     and reports any character encoding issues that it finds.
 
-+   *DocType* -- `doccheck` assumes that HTML files should use HTML5, and reports
++ *DocType* -- `doccheck` assumes that HTML files should use HTML5, and reports
     any files for which that is not the case.
 
-+   *Legal* -- `doccheck` checks for the presence of expected legal text, such as
++ *Legal* -- `doccheck` checks for the presence of expected legal text, such as
     copyright notices, near the end of each file.
 
-+   *Links* -- `doccheck` checks links within a set of files, and reports on links
++ *Links* -- `doccheck` checks links within a set of files, and reports on links
     to external resources, without otherwise checking them.
 
-+   *External Links* -- `doccheck` scans the files for URLs that refer to
++ *External Links* -- `doccheck` scans the files for URLs that refer to
     external resources, and validates those references. Each external reference 
     is only checked once; but if an issue is found, all the files containing the 
     reference will be reported.
@@ -121,6 +121,22 @@ The _options_ include:
     If the file is an existing directory, or ends with `/`, 
     the report will be split into separate files in the directory; 
     otherwise, all the output will be written to a single file.
+
+### `tidy`
+
+A suitable version of `tidy` should be available on the execution `PATH`.
+The output from the `--version` option should include a line containing the
+string `version 5`.  You can also override which version of `tidy` to use
+by setting the `tidy` system property.
+
+<div style="border: 1px solid red; border-radius: 10px; padding: 10px">
+Note that the version of <code>tidy</code> on macOS available by default in 
+<code>/usr/bin/tidy</code> is old and should <b>not</b> be used. 
+It does not support HTML&nbsp;5. This version identifies itself as:
+
+> HTML Tidy for Mac OS X released on 31 October 2006 - Apple Inc. build 2649
+</div>
+
 
 Reports
 -------


### PR DESCRIPTION
Update the version check for `tidy` to detect/reject use of very old versions of tidy, such as on macOS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [CODETOOLS-7903219](https://bugs.openjdk.org/browse/CODETOOLS-7903219)

### Issue
 * [CODETOOLS-7903219](https://bugs.openjdk.org/browse/CODETOOLS-7903219): improve check for old version of tidy ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/doccheck pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.org/doccheck pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/doccheck/pull/3.diff">https://git.openjdk.org/doccheck/pull/3.diff</a>

</details>
